### PR TITLE
Fix missing Flask request import

### DIFF
--- a/app/extensions.py
+++ b/app/extensions.py
@@ -3,7 +3,7 @@ from pymongo.server_api import ServerApi
 from elasticsearch import Elasticsearch
 import logging
 from functools import wraps
-from flask import current_app, jsonify, render_template
+from flask import current_app, jsonify, render_template, request
 
 # Configurar logging
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- fix `requires_elasticsearch` decorator by importing Flask's `request`

## Testing
- `python -m py_compile app/extensions.py`

------
https://chatgpt.com/codex/tasks/task_e_6856b0aa004083289baff8bb4688fdde